### PR TITLE
html_chromium: Disable DXVA acceleration

### DIFF
--- a/chromium_process/ChromiumApp.cpp
+++ b/chromium_process/ChromiumApp.cpp
@@ -189,7 +189,8 @@ void ChromiumApp::OnBeforeCommandLineProcessing( const CefString& process_type, 
 #endif
 
 	// https://bitbucket.org/chromiumembedded/cef/issues/2400
-	command_line->AppendSwitchWithValue( "disable-features", "TouchpadAndWheelScrollLatching,AsyncWheelEvents,HardwareMediaKeyHandling" );
+    // DXVAVideoDecoding must be disabled for Proton/Wine
+	command_line->AppendSwitchWithValue( "disable-features", "TouchpadAndWheelScrollLatching,AsyncWheelEvents,HardwareMediaKeyHandling,DXVAVideoDecoding" );
 
 	// Auto-play media
 	command_line->AppendSwitchWithValue( "autoplay-policy", "no-user-gesture-required" );

--- a/html_chromium/ChromiumSystem.cpp
+++ b/html_chromium/ChromiumSystem.cpp
@@ -41,11 +41,6 @@ public:
 		command_line->AppendSwitch( "enable-begin-frame-scheduling" );
 		// TODO: WINE/Proton support?
 		//command_line->AppendSwitch( "no-sandbox" );
-
-        // Disables DXVA acceleration, which should already be disabled but CEF seems to be
-        // re-enabling (see https://chromium-review.googlesource.com/c/chromium/src/+/4179889)
-        // This allows Proton/Wine to run video, since msvproc.dll doesn't exist in Wine
-        command_line->AppendSwitchWithValue( "disable-features", "DXVAVideoDecoding" );
 #endif
 		command_line->AppendSwitch( "enable-system-flash" );
 
@@ -59,7 +54,8 @@ public:
 #endif
 
 		// https://bitbucket.org/chromiumembedded/cef/issues/2400
-		command_line->AppendSwitchWithValue( "disable-features", "TouchpadAndWheelScrollLatching,AsyncWheelEvents,HardwareMediaKeyHandling" );
+        // DXVAVideoDecoding must be disabled for Proton/Wine
+		command_line->AppendSwitchWithValue( "disable-features", "TouchpadAndWheelScrollLatching,AsyncWheelEvents,HardwareMediaKeyHandling,DXVAVideoDecoding" );
 
 		// Auto-play media
 		command_line->AppendSwitchWithValue( "autoplay-policy", "no-user-gesture-required" );

--- a/html_chromium/ChromiumSystem.cpp
+++ b/html_chromium/ChromiumSystem.cpp
@@ -41,6 +41,11 @@ public:
 		command_line->AppendSwitch( "enable-begin-frame-scheduling" );
 		// TODO: WINE/Proton support?
 		//command_line->AppendSwitch( "no-sandbox" );
+
+        // Disables DXVA acceleration, which should already be disabled but CEF seems to be
+        // re-enabling (see https://chromium-review.googlesource.com/c/chromium/src/+/4179889)
+        // This allows Proton/Wine to run video, since msvproc.dll doesn't exist in Wine
+        command_line->AppendSwitchWithValue( "disable-features", "DXVAVideoDecoding" );
 #endif
 		command_line->AppendSwitch( "enable-system-flash" );
 


### PR DESCRIPTION
This allows Linux systems running GMod over Proton/Wine to play back videos, since they lack msvproc.dll (MF Video Processor required for DXVA2).

This may break native D3D9 clients' ability to play HW-accelerated videos, although I don't have a native Windows system to confirm this with.

Any system capable of using D3D11 should still have hardware acceleration with this change though, and it's already disabled by default in upstream Chromium for everything except PPAPI (see https://chromium-review.googlesource.com/c/chromium/src/+/4179889).