### PR TITLE
Add own gmod launcher executable with container detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,5 +71,8 @@ add_subdirectory(html_stub EXCLUDE_FROM_ALL)
 add_subdirectory(html_chromium)
 add_subdirectory(chromium_process)
 add_subdirectory(example_host EXCLUDE_FROM_ALL)
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  add_subdirectory(gmod)
+endif()
 
 PRINT_CEF_CONFIG()

--- a/gmod/CMakeLists.txt
+++ b/gmod/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(TARGET gmod)
+set(SOURCES
+	Main.c)
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--export-dynamic") # used for exposing the "has_namespace_support" variable for dlsym
+add_executable(${TARGET} ${SOURCES})
+target_link_libraries(${TARGET})

--- a/gmod/Main.c
+++ b/gmod/Main.c
@@ -1,0 +1,109 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <dlfcn.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sched.h>
+#define REALPATH_BUF_SIZE 4096
+#define LIBRARY_FILENAME "launcher_client.so"
+#define LIBRARY_LAUNCHER_FN "LauncherMain"
+typedef int (*arbitrary)();
+
+char has_namespace_support = 0x0;
+
+void calc_has_namespace_support()
+{
+    __pid_t clonedProcessPid;
+    __pid_t _Var1;
+    int unshareSuccessOrFail;
+    int *piVar3;
+    int status;
+
+    clonedProcessPid = fork();
+    if (clonedProcessPid == -1)
+    {
+        puts("fork failed... assuming unprivileged usernamespaces are disabled");
+    }
+    else
+    {
+        if (clonedProcessPid == 0)
+        {
+            unshareSuccessOrFail = unshare(0x10000000);
+            if (unshareSuccessOrFail != -1)
+            {
+                exit(0);
+            }
+            fprintf(stderr, "unshare(CLONE_NEWUSER) failed, unprivileged usernamespaces are probably disabled\n");
+            exit(1);
+        }
+        _Var1 = waitpid(clonedProcessPid, &status, 0);
+        if (clonedProcessPid == _Var1)
+        {
+            has_namespace_support = status == '\0';
+            return;
+        }
+        puts("waitpid failed... assuming unprivileged usernamespaces disabled");
+    }
+    return;
+}
+
+int main(int argc, char **argv)
+{
+    char realPathOut[4104];
+    char *unused;
+    int returnValue = 0;
+    if (getenv("container") || getenv("APPIMAGE") || getenv("SNAP"))
+    {
+        printf("[GModCefPatch] Overriding \"has_namespace_support\"...\n");
+        has_namespace_support = 1;
+    }
+    else
+        calc_has_namespace_support();
+    memset(realPathOut, 0, REALPATH_BUF_SIZE);
+    realpath("/proc/self/exe", realPathOut);
+    unused = strrchr(realPathOut, '/');
+    if (unused != (char *)0x0)
+    {
+        *unused = '\0';
+        unused = strrchr(realPathOut, '/');
+        if (unused != (char *)0x0)
+        {
+            *unused = '\0';
+            unused = strrchr(realPathOut, '/');
+            if (unused != (char *)0x0)
+            {
+                *unused = '\0';
+            }
+        }
+    }
+    chdir(realPathOut);
+    // char a[2000];
+    // getcwd(a, 2000);
+    // printf("%s\n", a);
+    void *launcherHandle = dlopen(LIBRARY_FILENAME, RTLD_NOW);
+    if (launcherHandle == 0)
+    {
+        char *errorMsg = dlerror();
+        fprintf(stderr, "Failed to load the launcher (%s)\n", errorMsg);
+        returnValue = 1;
+    }
+    else
+    {
+        arbitrary launcherMainFn;
+        *(void **)(&launcherMainFn) = dlsym(launcherHandle, LIBRARY_LAUNCHER_FN);
+        if (launcherMainFn == 0x0)
+        {
+            puts("Failed to load the launcher entry proc");
+            returnValue = 1;
+        }
+        else
+        {
+            returnValue = ((*launcherMainFn)(argc, argv));
+        }
+        dlclose(launcherHandle);
+    }
+    return returnValue;
+}

--- a/gmod/Main.c
+++ b/gmod/Main.c
@@ -17,10 +17,9 @@ char has_namespace_support = 0x0;
 void calc_has_namespace_support()
 {
     __pid_t clonedProcessPid;
-    __pid_t _Var1;
+    __pid_t stoppedProcessPid;
     int unshareSuccessOrFail;
-    int *piVar3;
-    int status;
+    int statusCode;
 
     clonedProcessPid = fork();
     if (clonedProcessPid == -1)
@@ -39,10 +38,10 @@ void calc_has_namespace_support()
             fprintf(stderr, "unshare(CLONE_NEWUSER) failed, unprivileged usernamespaces are probably disabled\n");
             exit(1);
         }
-        _Var1 = waitpid(clonedProcessPid, &status, 0);
-        if (clonedProcessPid == _Var1)
+        stoppedProcessPid = waitpid(clonedProcessPid, &statusCode, 0);
+        if (clonedProcessPid == stoppedProcessPid)
         {
-            has_namespace_support = status == '\0';
+            has_namespace_support = statusCode == '\0';
             return;
         }
         puts("waitpid failed... assuming unprivileged usernamespaces disabled");
@@ -80,9 +79,6 @@ int main(int argc, char **argv)
         }
     }
     chdir(realPathOut);
-    // char a[2000];
-    // getcwd(a, 2000);
-    // printf("%s\n", a);
     void *launcherHandle = dlopen(LIBRARY_FILENAME, RTLD_NOW);
     if (launcherHandle == 0)
     {


### PR DESCRIPTION
This PR adds custom GMod launcher that bypasses the namespace support check for Flatpak, Snap and other container-based GNU/Linux store apps.
The overall functionality should be the same as original launcher.